### PR TITLE
Fix release to properly release images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,26 +8,27 @@ CLUSTER_SETTINGS_FLAG = --cluster_settings $(DAPPER_SOURCE)/scripts/cluster_sett
 override CLUSTERS_ARGS += $(CLUSTER_SETTINGS_FLAG)
 override DEPLOY_ARGS += $(CLUSTER_SETTINGS_FLAG) --deploytool_broker_args '--service-discovery'
 
-subctl:
+config-git:
+	git config --global user.email "release@submariner.io";\
+	git config --global user.name "Automated Release"
+
+subctl: config-git
 	./scripts/subctl.sh $(SUBCTL_ARGS)
 
-_e2e: deploy
+e2e: deploy
 	./scripts/e2e.sh
-
-e2e:
-	source $${DAPPER_SOURCE}/scripts/lib/utils; \
-	determine_target_release; \
-	read_release_file; \
-	[ "$${release['status']}" != "released" ] || $(MAKE) _e2e
 
 clusters: subctl
 
-deploy: images
+deploy: import-images
 
 images:
 	./scripts/images.sh
 
-create-release:
+import-images: images
+	./scripts/import-images.sh
+
+create-release: config-git images
 	./scripts/release.sh
 
 validate:

--- a/releases/v0.8.0-pre0.yaml
+++ b/releases/v0.8.0-pre0.yaml
@@ -8,4 +8,4 @@ release-notes: |
   Here be dragons
 status: shipyard
 components:
-  shipyard: 5e8ab3e
+  shipyard: 7e63ce8

--- a/scripts/images.sh
+++ b/scripts/images.sh
@@ -5,7 +5,6 @@ set -e
 source ${DAPPER_SOURCE}/scripts/lib/image_defs
 source ${DAPPER_SOURCE}/scripts/lib/utils
 source ${SCRIPTS_DIR}/lib/debug_functions
-source ${SCRIPTS_DIR}/lib/deploy_funcs
 source ${SCRIPTS_DIR}/lib/version
 
 function _pull_image() {
@@ -17,14 +16,11 @@ function _pull_image() {
 
 function pull_images() {
     for project in ${PROJECTS[*]}; do
-        for image in ${project_images[${project}]}; do
-            if ! _pull_image "${release["components.${project}"]}"; then
-                clone_repo
-                local project_version=$(_git describe --tags --dirty="-${DEV_VERSION}" --exclude="${CUTTING_EDGE}" --exclude="latest")
-                _pull_image "$project_version"
-            fi
+        clone_repo
+        local project_version=$(_git describe --tags --exclude="${CUTTING_EDGE}" --exclude="latest")
 
-            import_image "${REPO}/${image}"
+        for image in ${project_images[${project}]}; do
+            _pull_image "$project_version"
         done
     done
 }

--- a/scripts/import-images.sh
+++ b/scripts/import-images.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+source ${DAPPER_SOURCE}/scripts/lib/image_defs
+source ${DAPPER_SOURCE}/scripts/lib/utils
+source ${SCRIPTS_DIR}/lib/debug_functions
+source ${SCRIPTS_DIR}/lib/deploy_funcs
+
+for project in ${PROJECTS[*]}; do
+    for image in ${project_images[${project}]}; do
+        import_image "${REPO}/${image}"
+    done
+done
+
+

--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -49,7 +49,7 @@ function _git() {
 }
 
 function clone_repo() {
-    local branch="${1:-${release["components.${project}"]}}"
+    local branch="${release["components.${project}"]:-master}"
     if [[ -d "projects/${project}" ]]; then
         _git fetch -f --tags
     else

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -53,14 +53,13 @@ function create_pr() {
     local msg="$2"
     local org=$(determine_org)
 
-    _git -c user.name='Automated Release' -c user.email='release@submariner.io' \
-        commit -a -s -m "${msg}"
+    _git commit -a -s -m "${msg}"
     _git push -f https://${GITHUB_ACTOR}:${RELEASE_TOKEN}@github.com/${org}/${project}.git ${branch}
     gh pr create --repo "${org}/${project}" --head ${branch} --base master --title "${msg}" --body "${msg}"
 }
 
 function pin_to_shipyard() {
-    clone_repo master
+    clone_repo
     _git checkout -B pin_shipyard origin/master
     sed -i -E "s/(shipyard-dapper-base):.*/\1:${release['version']#v}/" projects/${project}/Dockerfile.dapper
     update_go_mod shipyard
@@ -84,7 +83,7 @@ function release_shipyard() {
 }
 
 function pin_to_admiral() {
-    clone_repo master
+    clone_repo
     _git checkout -B pin_admiral origin/master
     update_go_mod admiral
     create_pr pin_admiral "Pin Admiral to ${release['version']}"
@@ -106,7 +105,7 @@ function release_admiral() {
 function update_operator_pr() {
     local project="submariner-operator"
 
-    clone_repo master
+    clone_repo
     _git checkout -B update_operator origin/master
     for target in ${OPERATOR_CONSUMES[*]} ; do
         update_go_mod "${target}"

--- a/scripts/subctl.sh
+++ b/scripts/subctl.sh
@@ -6,17 +6,46 @@ source ${DAPPER_SOURCE}/scripts/lib/utils
 source ${SCRIPTS_DIR}/lib/debug_functions
 source ${SCRIPTS_DIR}/lib/utils
 
+### Functions ###
+
+# Allow running dapper in dapper by some trickery
+function dapper_in_dapper() {
+    # Plant a directive in the Dockerfile.dapper to let dapper run in dapper
+    local orig_pwd=$(docker inspect $HOSTNAME | jq -r ".[0].Mounts[] | select(.Destination == \"$DAPPER_SOURCE\") | .Source")
+    local cur_pwd=$(pwd | sed -E 's/[a-zA-Z0-9-]+/../g')
+    echo "ENV DAPPER_CP=${cur_pwd}/${orig_pwd}/projects/submariner-operator" >> Dockerfile.dapper
+
+    # Trick our own Makefile to think we're running outside dapper
+    export DAPPER_HOST_ARCH=""
+
+    # Commit and tag so that we get a correct "version" calculated
+    git commit -a -m "DAPPER IN DAPPER"
+    git tag -f ${release["version"]}
+}
+
+function cleanup_dapper_in_dapper() {
+    # Remove last commit which was needed to run dapper in dapper
+    git reset --hard HEAD^
+
+    # Remove local tag so not to interfere
+    git tag -d ${release["version"]}
+}
+
+### Main ###
+
 determine_target_release
 read_release_file
 
 project=submariner-operator
 clone_repo
 
-pushd projects/submariner-operator
-export VERSION="${release["version"]}"
-[[ "$1" == "cross" ]] && make build-cross
-make bin/subctl
-ln -f -s $(pwd)/bin/subctl /go/bin/subctl
-./bin/subctl version
-popd
+    pushd projects/submariner-operator
+    dapper_in_dapper
+
+    [[ "$1" == "cross" ]] && make build-cross
+    make bin/subctl
+
+    ln -f -s $(pwd)/bin/subctl /go/bin/subctl
+    ./bin/subctl version
+    cleanup_dapper_in_dapper
 


### PR DESCRIPTION
Release was trying to release images without pulling them.
Release now depends on images which will always try to pull the
necessary images.
As a consequence, we can now always run E2E with master branch in case
we're in a partial stage and some of the components aren't known yet.

Also fixed subctl building which was broken due to recent changes in
submariner-operator.
It should now work and be more robust, as we're essentially running the
whole build "dapper in dapper".

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>