### PR TITLE
Fix target release detection

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Run E2E deployment and tests
         uses: submariner-io/shipyard/gh-actions/e2e@devel

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Validate release YAMLs
         run: make validate

--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -17,7 +17,9 @@ function printerr() {
 }
 
 function determine_target_release() {
-    file=$(git diff-tree --name-only -r HEAD | grep -m1 "releases/v.*\.yaml" || :)
+    local commit_id=HEAD
+    [[ $(git cat-file -p HEAD | grep -e"^parent " | wc -l) -gt 1 ]] && commit_id="HEAD~1"
+    file=$(git diff-tree --name-only -r "${commit_id}" | grep -m1 "releases/v.*\.yaml" || :)
 
     if [[ -z "$file" ]]; then
         echo "WARN: Couldn't detect a target release file, skipping."


### PR DESCRIPTION
Seems that on pull request (and perhaps if we merge a PR with a merge
commit) the auto detection of commit fails because it only considers the
merge commit.

Now if will take the commit right before the merge commit in case the
latest commit is a merge commit.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
